### PR TITLE
Inform github about leoninleague.ch

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+leoninleague.ch


### PR DESCRIPTION
See [0]. I configured leoninleague.ch to point to Github's public IP address. I tested by going to the page and seeing that there is a 404 here, meaning github does not know which site should be served.

[0] https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site